### PR TITLE
Ensure gateways for one iface can't polute another (edge case)

### DIFF
--- a/netinfo/__init__.py
+++ b/netinfo/__init__.py
@@ -217,7 +217,7 @@ class InterfaceInfo:
                 return None
 
         for line in route_n.splitlines():
-            regex = rf"^0.0.0.0\s+(.*?)\s+(.*)\s+{self.ifname}"
+            regex = rf"^0\.0\.0\.0\s+(.*?)\s+(.*)\s+{re.escape(self.ifname)}(?:\s|$)"
             m = re.search(regex, line, re.M)
             if m:
                 return m.group(1)


### PR DESCRIPTION
Minor edge case fix. Previous regex had no end anchor - so would match `eth01` too (and return `eth0` gateway). Edge case as it's "advanced" network config, but is valid and possible.